### PR TITLE
implement aliases

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,3 +7,6 @@ approvers:
 features:
   - comments
   - reviewers
+
+aliases:
+  - plugin: {1} -> label add: plugin/{1}

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 Dreck can help you with Pull Requests and Issues on your GitHub project
 
 Dreck is a fork of [Derek](https:/github.com/alexellis/derek). It adds Caddy integration, so you can
-just run it as a plugin in Caddy and a bunch of other features.
+"just" run it as a plugin in Caddy and a bunch of other features.
 
 For this all to work, you'll need to have an Github App that allows access to your repo - setting
-this up is beyond scope of this documentation. And need to recompile Caddy and have a function Go
-setup; again: beyond the scope of this document.
+this up is beyond scope of this documentation. And need to recompile Caddy and have a functional Go
+setup; again: all beyond the scope of this document.
 
 ## Config in caddy
 
@@ -62,6 +62,8 @@ reviewers:
     - miek
 features:
     - comments
+aliases:
+    - a1 -> b1
 ~~~
 
 ### Features
@@ -109,6 +111,20 @@ Further more the following command is support for PR issues comments (ignored fo
 
 * `/lgtm`, approve the PR.
 
-# Bugs
+## Aliases
+
+The `aliases` sections of the OWNERS file allows you to specify alias for other commands. It's
+a regular expression based format and looks like this: `alias -> command`. Note the this is:
+`<space>-><space>`, e.g.:
+
+~~~
+/plugin: (.*) -> /label add: plugin/$1
+~~~
+
+This defines a new command `/plugin: forward` that translates into `/label add: plugin/forward`.
+The regular expression `(.*)` catches the argument after `/plugin: ` and `$1` is the first expression
+match group.
+
+## Bugs
 
 We don't support multiple commands in an issue.

--- a/alias.go
+++ b/alias.go
@@ -1,0 +1,36 @@
+package dreck
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Rule write an alias' from to to.
+type Rule struct {
+	from    *regexp.Regexp
+	replace string
+}
+
+// Expand will use R to expand the command.
+func (r Rule) Expand(src string) string {
+	return r.from.ReplaceAllString(src, r.replace)
+}
+
+// NewAlias inspects command to see if it is a correct alias.
+func NewAlias(command string) (Rule, error) {
+	var err error
+	splits := strings.Split(command, sep)
+	if len(splits) != 2 {
+		return Rule{}, fmt.Errorf("could not find alias in %s", command)
+	}
+	r := Rule{replace: splits[1]}
+	r.from, err = regexp.Compile(splits[0])
+	if err != nil {
+		return r, err
+	}
+
+	return r, nil
+}
+
+const sep = " -> "

--- a/alias_test.go
+++ b/alias_test.go
@@ -1,0 +1,95 @@
+package dreck
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/miekg/dreck/types"
+)
+
+func TestAlias(t *testing.T) {
+	alias := "/plugin: (.*) -> /label add: plugin/$1"
+
+	r, err := NewAlias(alias)
+	if err != nil {
+		t.Errorf("Failed to parse %s: %v", alias, err)
+	}
+	input := "/plugin: example"
+	exp := r.Expand(input)
+	if exp == input {
+		t.Errorf("Failed to expand %s", input)
+	}
+
+	t.Logf("Got %s\n", exp)
+}
+
+func TestAliasParse(t *testing.T) {
+	alias := "/plugin: (.*) - /label add: plugin/$1"
+	if _, err := NewAlias(alias); err == nil {
+		t.Errorf("Expected to not parse %s", alias)
+	}
+
+	alias = "/plugin: (*) - /label add: plugin/$1"
+	if _, err := NewAlias(alias); err == nil {
+		t.Errorf("Expected to not parse %s", alias)
+	}
+}
+
+func TestParsingAlias(t *testing.T) {
+
+	conf := &types.DreckConfig{
+		Aliases: []string{
+			fmt.Sprintf("%splugin: (.*) -> %slabel add: plugin/$1", Trigger, Trigger),
+			fmt.Sprintf("%splugin2: (.*) -> %slabel add: plugin/$2", Trigger, Trigger),
+			fmt.Sprintf("%slooksOK -> %slgtm", Trigger, Trigger),
+		},
+	}
+
+	var options = []struct {
+		title        string
+		body         string
+		expectedType string
+		expectedVal  string
+	}{
+		{
+			title:        "Alias Add label of demo",
+			body:         Trigger + "plugin: demo",
+			expectedType: "AddLabel",
+			expectedVal:  "plugin/demo",
+		},
+		{
+			title:        "Alias2 Add label of demo",
+			body:         Trigger + "plugin2: demo",
+			expectedType: "AddLabel",
+			expectedVal:  "plugin/",
+		},
+		{
+			title:        "Alias Add label of demo",
+			body:         Trigger + "plugin: demo",
+			expectedType: "AddLabel",
+			expectedVal:  "plugin/demo",
+		},
+		{
+			title:        "Non alias label of demo",
+			body:         Trigger + "pluginner: demo",
+			expectedType: "",
+			expectedVal:  "",
+		},
+		{
+			title:        "Lgtm",
+			body:         Trigger + "looksOK",
+			expectedType: "lgtm",
+			expectedVal:  "",
+		},
+	}
+
+	for _, test := range options {
+		t.Run(test.title, func(t *testing.T) {
+
+			action := parse(test.body, conf)
+			if action.Type != test.expectedType || action.Value != test.expectedVal {
+				t.Errorf("Action - wanted: %s, got %s\nLabel - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
+			}
+		})
+	}
+}

--- a/comment-handler_test.go
+++ b/comment-handler_test.go
@@ -43,7 +43,7 @@ func TestParsingOpenClose(t *testing.T) {
 	for _, test := range actionOptions {
 		t.Run(test.title, func(t *testing.T) {
 
-			action := parse(test.body)
+			action := parse(test.body, &types.DreckConfig{})
 
 			if action.Type != test.expectedAction {
 				t.Errorf("Action - want: %s, got %s", test.expectedAction, action.Type)
@@ -84,7 +84,7 @@ func TestParsingLabels(t *testing.T) {
 	for _, test := range labelOptions {
 		t.Run(test.title, func(t *testing.T) {
 
-			action := parse(test.body)
+			action := parse(test.body, &types.DreckConfig{})
 			if action.Type != test.expectedType || action.Value != test.expectedVal {
 				t.Errorf("Action - wanted: %s, got %s\nLabel - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
 			}
@@ -141,7 +141,7 @@ func TestParsingAssignments(t *testing.T) {
 	for _, test := range assignmentOptions {
 		t.Run(test.title, func(t *testing.T) {
 
-			action := parse(test.body)
+			action := parse(test.body, &types.DreckConfig{})
 			if action.Type != test.expectedType || action.Value != test.expectedVal {
 				t.Errorf("Action - wanted: %s, got %s\nMaintainer - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
 			}
@@ -186,7 +186,7 @@ func TestParsingTitles(t *testing.T) {
 	for _, test := range titleOptions {
 		t.Run(test.title, func(t *testing.T) {
 
-			action := parse(test.body)
+			action := parse(test.body, &types.DreckConfig{})
 			if action.Type != test.expectedType || action.Value != test.expectedVal {
 				t.Errorf("\nAction - wanted: %s, got %s\nValue - wanted: %s, got %s", test.expectedType, action.Type, test.expectedVal, action.Value)
 			}

--- a/http.go
+++ b/http.go
@@ -83,7 +83,7 @@ func (d Dreck) handleEvent(eventType string, body []byte) error {
 			}
 		}
 
-		// Reviewers, only on PR opens
+		// Reviewers, only on PR opens.
 		if req.Action == openPRConst {
 			if enabledFeature(featureReviewers, conf) {
 				if err := d.pullRequestReviewers(req); err != nil {
@@ -112,7 +112,7 @@ func (d Dreck) handleEvent(eventType string, body []byte) error {
 		}
 
 		if permittedUserFeature(featureComments, conf, req.Comment.User.Login) {
-			err := d.comment(req)
+			err := d.comment(req, conf)
 			if err != nil {
 				return err
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -62,7 +62,9 @@ type CommentAction struct {
 	Value string
 }
 
+// DreckConfig holds the configuration from the top-level owners file.
 type DreckConfig struct {
+	Aliases   []string
 	Features  []string
 	Reviewers []string
 	Approvers []string


### PR DESCRIPTION
Allow for aliases to be specified, so we can do

/plugin: forward

to mean: '/label add: plugin/forward'. This can be quite convient.