### PR TITLE
Ignore case in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Build Status](https://travis-ci.org/miekg/dreck.svg?branch=master)](https://travis-ci.org/miekg/dreck)
 
-Dreck can help you with managing Pull Requests and Issues on your GitHub project. Dreck currently
+Dreck can help you with managing pull requests and issues in your GitHub project. Dreck currently
 can:
 
-* Assign reviewers to a pull request based on OWNERS file.
+* Assign reviewers to a pull request based on OWNERS files.
 * Automatically delete the branch when a pull request is merged.
 * Automatically merge a pull request when the status is green.
 * Label/close/lock etc. issues
@@ -100,6 +100,8 @@ The following features are available.
 When using email to reply to an issue, the email *must* start with the command, i.e. `/label rm: bug`
 and include no lines above that.
 
+Commands and aliases are detected in a case insensitive manner.
+
 Multiple command in one message/issue are not supported.
 
 ## Supported Commands
@@ -121,6 +123,8 @@ The following commands are supported.
 * `/title edit: TITLE`, set the title to TITLE.
 * `/lock`, lock the issue.
 * `/unlock`, unlock the issue.
+
+The case of these commands is ignored.
 
 ### Pull Requests
 
@@ -153,6 +157,8 @@ This defines a new command `/plugin: forward` that translates into `/label add: 
 The regular expression `(.*)` catches the argument after `/plugin: ` and `$1` is the first expression
 match group.
 
+The alias expansion is done is a case insensitive manner.
+
 Note this entire string needs to be taken literal in the OWNERS file to be valid yaml:
 
 ~~~ yaml
@@ -169,4 +175,4 @@ excluded from this.
 
 ## Bugs
 
-We don't support multiple commands in an issue.
+We don't support multiple commands in an comment issue.

--- a/alias.go
+++ b/alias.go
@@ -25,7 +25,7 @@ func NewAlias(command string) (Rule, error) {
 		return Rule{}, fmt.Errorf("could not find alias in %s", command)
 	}
 	r := Rule{replace: splits[1]}
-	r.from, err = regexp.Compile(splits[0])
+	r.from, err = regexp.Compile("(?i)" + splits[0]) // (?i) makes it case insentive.
 	if err != nil {
 		return r, err
 	}

--- a/alias_test.go
+++ b/alias_test.go
@@ -71,6 +71,12 @@ func TestParsingAlias(t *testing.T) {
 			expectedVal:  "plugin/demo",
 		},
 		{
+			title:        "Alias Add label of demo case",
+			body:         Trigger + "plUGin: demo",
+			expectedType: "AddLabel",
+			expectedVal:  "plugin/demo",
+		},
+		{
 			title:        "Non alias label of demo",
 			body:         Trigger + "pluginner: demo",
 			expectedType: "",

--- a/comment-handler.go
+++ b/comment-handler.go
@@ -239,6 +239,7 @@ func parse(body string, conf *types.DreckConfig) *types.CommentAction {
 	return &types.CommentAction{}
 }
 
+// isValidCommand checks the body of the comment to see if trigger is present.
 func isValidCommand(body string, trigger string, conf *types.DreckConfig) (bool, string) {
 	if ok := enabledFeature(featureAliases, conf); ok {
 		for _, a := range conf.Aliases {
@@ -252,12 +253,16 @@ func isValidCommand(body string, trigger string, conf *types.DreckConfig) (bool,
 	}
 
 	val := ""
-	ok := (len(body) > len(trigger) && body[0:len(trigger)] == trigger) ||
-		(body == trigger && !strings.HasSuffix(trigger, ": "))
+	trigger = strings.ToLower(trigger)
+
+	ok := (len(body) > len(trigger) && strings.ToLower(body[0:len(trigger)]) == trigger) ||
+		(strings.ToLower(body) == trigger && !strings.HasSuffix(trigger, ": "))
+
 	if ok {
 		val = body[len(trigger):]
 		val = strings.Trim(val, " \t.,\n\r")
 	}
+
 	return ok, val
 }
 

--- a/comment-handler_test.go
+++ b/comment-handler_test.go
@@ -16,9 +16,14 @@ var actionOptions = []struct {
 		body:           Trigger + "reopen",
 		expectedAction: reopenConst,
 	},
-	{ //this case replaces Test_Parsing_Close
+	{
 		title:          "Correct close command",
 		body:           Trigger + "close",
+		expectedAction: closeConst,
+	},
+	{
+		title:          "Uppercase close command",
+		body:           Trigger + "cLOse",
 		expectedAction: closeConst,
 	},
 	{

--- a/merge.go
+++ b/merge.go
@@ -62,7 +62,7 @@ func (d Dreck) pullRequestMerge(ctx context.Context, client *github.Client, req 
 		return fmt.Errorf("failed merge of PR %d: %s", *pull.Number, err.Error())
 	}
 
-	log.Infof("PR %d has been autosubmitted", req.Issue.Number)
+	log.Infof("PR %d has been autosubmitted in %s", req.Issue.Number, commit.GetSHA())
 
 	return nil
 }


### PR DESCRIPTION
In both command and alias ignore the case when detecting these.

Fixes: #62