### PR TITLE
Rename run -> exec

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,19 +4,16 @@ reviewers:
 approvers:
   - miekg
 
-runners:
-  - miekg
-
 features:
   - comments
   - reviewers
   - aliases
   - branches
   - autosubmit
-  - run
+  - exec
 
 aliases:
   - |
     /plugin: (.*) -> /label add: plugin/$1
   - |
-    /release: (.*) -> /run: /opt/bin/release $1
+    /release: (.*) -> /exec: /opt/bin/release $1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ can:
 * Automatically delete the branch when a pull request is merged.
 * Automatically merge a pull request when the status is green.
 * LGTM a pull request with a comment.
-* Run (whitelisted) commands on the dreck server.
+* Execute (whitelisted) commands on the dreck server.
 
 Dreck is a fork of [Derek](https://github.com/alexellis/derek). It adds Caddy integration, so you can
 "just" run it as a plugin in Caddy. It also massively expands on the number of features.
@@ -78,16 +78,14 @@ approvers:
     - miek
 reviewers:
     - miek
-runners:
-    - miek
 features:
     - comments
-    - run
+    - exec
 aliases:
     - |
       /plugin: (.*) -> /label add: plugin/$1
     - |
-      /release: (.*) -> /run: /opt/bin/release $1
+      /release: (.*) -> /exec: /opt/bin/release $1
 ~~~
 
 ### Features
@@ -102,7 +100,7 @@ The following features are available.
 * `aliases` - enable alias expansion.
 * `branches` - enables the deletion of branches after a merge of a pull request.
 * `autosubmit` - enables `/autosubmit`.
-* `run` - enables `/run`.
+* `exec` - enables `/exec`.
 
 When using email to reply to an issue, the email *must* start with the command, i.e. `/label rm: bug`
 and include no lines above that.
@@ -130,8 +128,8 @@ The following commands are supported.
 * `/title edit: TITLE`, set the title to **TITLE**.
 * `/lock`, lock the issue.
 * `/unlock`, unlock the issue.
-* `/run COMMAND`, run **COMMAND** on the dreck server. Can only be performed by runners, and only
-  via an expanded alias.
+* `/exec COMMAND`, executes **COMMAND** on the dreck server. Only commands via an expanded alias
+  are allowed.
 
 The case of these commands is ignored.
 
@@ -177,23 +175,23 @@ aliases:
       /plugin: (.*) -> /label add: plugin/$1
 ~~~
 
-### Run
+### Exec
 
-Run allows for processes be started on the dreck server. For this the `run` feature *and* the
-`aliases` feature must be enabled. Next runners must be defined in the OWNERS file. Only commands
-*expanded* by an alias are allowed to run, this is to prevent things like `/run /bin/cat
-/etc/passwd` to be run accidentally. The standard output of the command will be picked up and put in
-the new comment under the issue or pull request.
+Exec allows for processes be started on the dreck server. For this the `exec` feature *and* the
+`aliases` feature must be enabled. Only commands
+*expanded* by an alias are allowed to execute, this is to prevent things like `/exec: /bin/cat
+ /etc/passwd` to be run accidentally. The standard output of the command will be picked up and put
+ in the new comment under the issue or pull request.
 
-All commands run will get one default argument, which is either the issue or pull request number,
-if the command is given in an issue dreck will run `/cmd issue:NUMBER`, if done for a pull request
-that parameter will be `/cmd pull:NUMBER`.
+All commands executed will get one default argument, which is either the issue or pull request number,
+if the command is given in an issue dreck will run `/bin/cmd issue:NUMBER`, if done for a pull request
+that parameter will be `/bin/cmd pull:NUMBER`.
 
-For example, if you want to run `/opt/bin/release ARGUMENT` on the server, the following alias must
+For example, if you want to exceute `/opt/bin/release ARGUMENT` on the server, the following alias must
 be there:
 
 ~~~
-/release: (.*) -> /run: /opt/bin/release $1
+/release: (.*) -> /exec: /opt/bin/release $1
 ~~~
 
 If you then call the command with `/release 0.1` in issue 42. Dreck will run:
@@ -202,7 +200,7 @@ If you then call the command with `/release 0.1` in issue 42. Dreck will run:
 /opt/bin/release issue:42 0.1
 ~~~
 
-Note that in this case `/cat -> /run: /bin/cat /etc/resolv.conf`, running `cat /etc/passwd` *still*
+Note that in this case `/cat -> /exec: /bin/cat /etc/resolv.conf`, running `cat /etc/passwd` *still*
 yields in an (unwanted?) disclosure because the final command being run is `/bin/cat
 /etc/resolv.conf /etc/passwd`. In other words be careful of what commands you whitelist.
 

--- a/comment-handler.go
+++ b/comment-handler.go
@@ -25,7 +25,7 @@ const (
 	addLabelConst    = "AddLabel"
 	lgtmConst        = "lgtm"
 	autosubmitConst  = "autosubmit"
-	runConst         = "run"
+	execConst        = "exec"
 )
 
 func (d Dreck) comment(req types.IssueCommentOuter, conf *types.DreckConfig) error {
@@ -50,15 +50,15 @@ func (d Dreck) comment(req types.IssueCommentOuter, conf *types.DreckConfig) err
 			return d.autosubmit(req)
 		}
 		return fmt.Errorf("user %s not permitted to use %s or this feature is disabled", req.Comment.User.Login, autosubmitConst)
-	case runConst:
+	case execConst:
 		if !enabledFeature(featureAliases, conf) {
-			return fmt.Errorf("feature %s is not enabled, so /run can't work", featureAliases)
+			return fmt.Errorf("feature %s is not enabled, so %s can't work", Trigger+execConst, featureAliases)
 		}
-		if !permittedUserFeatureRun(conf, req.Comment.User.Login) {
-			return fmt.Errorf("user %s not permitted to use %s or this feature is disabled", req.Comment.User.Login, runConst)
+		if !permittedUserFeature(featureExec, conf, req.Comment.User.Login) {
+			return fmt.Errorf("user %s not permitted to use %s or this feature is disabled", req.Comment.User.Login, execConst)
 		}
 
-		return d.run(req, conf, command.Type, command.Value)
+		return d.exec(req, conf, command.Type, command.Value)
 	}
 
 	if len(req.Comment.Body) > 25 {
@@ -306,7 +306,7 @@ var IssueCommands = map[string]string{
 	Trigger + "title edit: ":   setTitleConst,
 	Trigger + "lock":           lockConst,
 	Trigger + "unlock":         unlockConst,
-	Trigger + "run":            runConst,        // Only works for runners.
+	Trigger + "exec":           execConst,
 	Trigger + "lgtm":           lgtmConst,       // Only works on Pull Requests comments.
 	Trigger + "autosubmit":     autosubmitConst, // Only works on Pull Request comments.
 }

--- a/dreck.go
+++ b/dreck.go
@@ -39,8 +39,8 @@ const (
 	featureBranches = "branches"
 	// featureAutosubmit enables the auto submitting or pull requests when the tests are green.
 	featureAutosubmit = "autosubmit"
-	// featureRun enables the run command.
-	featureRun = "run"
+	// featureExec enables the exec command.
+	featureExec = "exec"
 )
 
 // Trigger is the prefix that triggers action from this bot.

--- a/exec_test.go
+++ b/exec_test.go
@@ -2,7 +2,7 @@ package dreck
 
 import "testing"
 
-func TestRunSanitize(t *testing.T) {
+func TestExecSanitize(t *testing.T) {
 	tests := []struct {
 		in string
 		ok bool

--- a/perm-handler.go
+++ b/perm-handler.go
@@ -37,18 +37,6 @@ func permittedUserFeature(attemptedFeature string, config *types.DreckConfig, us
 	return false
 }
 
-func permittedUserFeatureRun(config *types.DreckConfig, user string) bool {
-	if enabledFeature(featureRun, config) {
-		for _, runner := range config.Runners {
-			if strings.EqualFold(user, runner) {
-				return true
-			}
-		}
-
-	}
-	return false
-}
-
 func (d Dreck) getConfig(owner string, repository string) (*types.DreckConfig, error) {
 
 	var config types.DreckConfig

--- a/types/types.go
+++ b/types/types.go
@@ -69,5 +69,4 @@ type DreckConfig struct {
 	Features  []string
 	Reviewers []string
 	Approvers []string
-	Runners   []string
 }


### PR DESCRIPTION
Remove "runners" from the owners file, just use the current set of
reviewers and approvers.

Rename run to exec and update the documentation and code.

Simplifies things a bit and it requires less code.

/autosubmit