### PR TITLE
Add entry "security:" in OWNER file

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -30,6 +30,19 @@ func TestReviewerConfigParse(t *testing.T) {
 	}
 }
 
+func TestSecurityConfigParse(t *testing.T) {
+	config := types.DreckConfig{}
+	parseConfig([]byte(`security:
+- s1
+- s2
+- s3
+`), &config)
+	actual := len(config.Security)
+	if actual != 3 {
+		t.Errorf("want: %d security, got: %d", 3, actual)
+	}
+}
+
 func TestAliasConfigParse(t *testing.T) {
 	config := types.DreckConfig{}
 	err := parseConfig([]byte(`aliases:
@@ -50,7 +63,9 @@ func TestConfigParse(t *testing.T) {
 	err := parseConfig([]byte(`reviewers:
 - aa
 - ac
-
+security:
+- one
+- two
 aliases:
 - >
   /plugin: (.*) - /label add: plugin/$1

--- a/types/types.go
+++ b/types/types.go
@@ -69,6 +69,7 @@ type DreckConfig struct {
 	Features  []string
 	Reviewers []string
 	Approvers []string
+	Security  []string
 }
 
 // PullRequestToIssueComment converts one type to another. This is not a full copy, but copies


### PR DESCRIPTION

In order to be able to enumerates all participants to the Patch Security Team, I created an entry "security:" in the ownerConfig structure.

OWNER file is expected to looks like:

```
approvers:
  - randomguy
  - anotherguy

security:
  - randomguy

features:
  - comments
  - reviewers
  - aliases
  - branches
  - exec


aliases:
  - |
    /plugin: (.*) -> /label add: plugin/$1
```